### PR TITLE
Bug fix: "Key.xxx" can't be replayed

### DIFF
--- a/src/macro/macro.py
+++ b/src/macro/macro.py
@@ -1,6 +1,7 @@
 from tkinter import *
 from tkinter import messagebox
 from pynput import mouse, keyboard
+from pynput.keyboard import Key
 from pynput.mouse import Button
 from utils.get_key_pressed import getKeyPressed
 from utils.record_file_management import RecordFileManagement


### PR DESCRIPTION
`src/macro/macro.py` line 231:
![image](https://github.com/LOUDO56/PyMacroRecord/assets/58882256/2916a88e-481b-4879-bf4a-0a65663d263a)
The “eval” statement in this code will never be successfully executed, because the Key module has not been imported.