### PR TITLE
fix for platform-specific requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ If you encounter a bug or want to request an update, simply create an issue [her
   pip3 install -r requirements.txt
   ```
   - If you are on **Linux**, you might need to install Tkinter manually, commands to install are [here](https://www.geeksforgeeks.org/how-to-install-tkinter-on-linux/)
-  - You need to remove the **win10toast** from `requirements.txt` if you are not on windows or else you won't be able to install the depedencies
   - Mac Users, you must add terminal to accessibility and input monitoring settings in system preferences to allow mouse and keyboard inputs.
   - (Optional) If you want these package to be on virtual environment follow these step [here](https://stackoverflow.com/a/41799834)
 - Finally, do `cd src` and type: `python3 main.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Pillow==10.3.0
 pynput==1.7.7
 pystray==0.19.5
 Requests==2.32.0
-win10toast==0.9
+win10toast==0.9; sys_platform == 'win32'


### PR DESCRIPTION
Greetings!

We are able to use conditional requirements on platform-basis.

Not completely sure if this may be a problem for the windows builds though.