### PR TITLE
Cleanup resource_path usage

### DIFF
--- a/src/utils/get_file.py
+++ b/src/utils/get_file.py
@@ -1,10 +1,20 @@
 import sys
 from os import path
+from pathlib import Path
 
-def resource_path(relative_path):
+
+def resource_path(relative_path: (str, list)) -> str:
     """ Get absolute path to resource, works for dev and for PyInstaller """
-    try:
+    if hasattr(sys, '_MEIPASS'):
         base_path = sys._MEIPASS
-    except Exception:
-        base_path = path.abspath(".")
-    return path.join(base_path, relative_path)
+
+    else:
+        base_path = Path(__file__).parent.parent
+
+    if not isinstance(relative_path, list):
+        relative_path = [relative_path]
+
+    for sub_path in relative_path:
+        base_path = path.join(base_path, sub_path)
+
+    return base_path

--- a/src/utils/record_file_management.py
+++ b/src/utils/record_file_management.py
@@ -1,6 +1,5 @@
 from tkinter import *
 from tkinter import filedialog
-from os import path
 from json import load, dumps
 
 from utils import UserSettings

--- a/src/utils/show_toast.py
+++ b/src/utils/show_toast.py
@@ -1,4 +1,4 @@
-from os import path, system
+from os import system
 from sys import platform
 from utils.get_file import resource_path
 
@@ -18,7 +18,7 @@ def show_notification_minim(main_app):
                 title="PyMacroRecord",
                 msg=main_app.text_content["options_menu"]["settings_menu"]["minimization_toast"],
                 duration=3,
-                icon_path=resource_path(path.join("assets", "logo.ico"))
+                icon_path=resource_path(["assets", "logo.ico"])
             )
         except:
             pass

--- a/src/windows/main/main_app.py
+++ b/src/windows/main/main_app.py
@@ -13,7 +13,6 @@ from utils.version import Version
 from windows.others.new_ver_avalaible import NewVerAvailable
 from hotkeys.hotkeys_manager import HotkeysManager
 from macro import Macro
-from os import path
 from sys import platform, argv
 from pystray import Icon
 from pystray import MenuItem
@@ -33,12 +32,12 @@ class MainApp(Window):
         super().__init__("PyMacroRecord", 350, 200)
         self.attributes("-topmost", 1)
         if platform == "win32":
-            self.iconbitmap(resource_path(path.join("assets", "logo.ico")))
+            self.iconbitmap(resource_path(["assets", "logo.ico"]))
 
         self.settings = UserSettings(self)
 
         self.lang = self.settings.get_config()["Language"]
-        with open(resource_path(path.join('langs',  self.lang+'.json')), encoding='utf-8') as f:
+        with open(resource_path(['langs',  f'{self.lang}.json']), encoding='utf-8') as f:
             self.text_content = json.load(f)
 
         self.text_content = self.text_content["content"]
@@ -61,7 +60,7 @@ class MainApp(Window):
         # Main Buttons (Start record, stop record, start playback, stop playback)
 
         # Play Button
-        self.playImg = PhotoImage(file=resource_path(path.join("assets", "button", "play.png")))
+        self.playImg = PhotoImage(file=resource_path(["assets", "button", "play.png"]))
 
         # Import record if opened with .pmr extension
         if len(argv) > 1:
@@ -76,12 +75,12 @@ class MainApp(Window):
         self.playBtn.pack(side=LEFT, padx=50)
 
         # Record Button
-        self.recordImg = PhotoImage(file=resource_path(path.join("assets", "button", "record.png")))
+        self.recordImg = PhotoImage(file=resource_path(["assets", "button", "record.png"]))
         self.recordBtn = Button(self, image=self.recordImg, command=self.macro.start_record)
         self.recordBtn.pack(side=RIGHT, padx=50)
 
         # Stop Button
-        self.stopImg = PhotoImage(file=resource_path(path.join("assets", "button", "stop.png")))
+        self.stopImg = PhotoImage(file=resource_path(["assets", "button", "stop.png"]))
 
         record_management = RecordFileManagement(self, self.menu)
 
@@ -108,7 +107,7 @@ class MainApp(Window):
 
     def systemTray(self):
         """Just to show little icon on system tray"""
-        image = Image.open(resource_path(path.join("assets", "logo.ico")))
+        image = Image.open(resource_path(["assets", "logo.ico"]))
         menu = (
             MenuItem('Show', action=self.deiconify, default=True),
         )


### PR DESCRIPTION
Greetings!

This is only a recommendation.
This PR cleans up the resource_path function and usage:
* Removed bad-practice `except Exception` catch
* Moved `path.join` calls into the `resource_path` function
* Better path-handling for direct execution (failed before when the current-working-directory is not the sources-root)