### PR TITLE
Fix boolean comparisons

### DIFF
--- a/src/hotkeys/hotkeys_manager.py
+++ b/src/hotkeys/hotkeys_manager.py
@@ -39,14 +39,14 @@ class HotkeysManager:
     def __win32_event_filter(self, msg, data):
         """Detect if key is pressed by real keyboard or pynput"""
         if data.flags == 0x10:
-            if self.macro.playback == True and self.macro.record == False:
+            if self.macro.playback and not self.macro.record:
                 return False
             else:
                 return True
 
     def __on_press(self, key):
         userSettings = self.settings.get_config()
-        if self.changeKey == True:
+        if self.changeKey:
             keyPressed = getKeyPressed(self.keyboard_listener, key)
             if keyPressed not in self.hotkeys:
                 if ">" in keyPressed:
@@ -86,7 +86,7 @@ class HotkeysManager:
                 self.hotkeys = []
                 self.hotkey_visible = []
 
-        if self.changeKey == False and self.main_app.prevent_record == False:
+        if not self.changeKey and not self.main_app.prevent_record:
             keyPressed = getKeyPressed(self.keyboard_listener, key)
             if ">" in keyPressed:
                 try:
@@ -101,30 +101,30 @@ class HotkeysManager:
             by_hotkey = True
             if (
                 self.hotkey_detection == userSettings["Hotkeys"]["Record_Start"]
-                and self.macro.record == False
-                and self.macro.playback == False
+                and not self.macro.record
+                and not self.macro.playback
             ):
                 self.macro.start_record(by_hotkey)
 
             elif (
                 self.hotkey_detection == userSettings["Hotkeys"]["Record_Stop"]
-                and self.macro.record == True
-                and self.macro.playback == False
+                and self.macro.record
+                and not self.macro.playback
             ):
                 self.macro.stop_record()
 
             elif (
                 self.hotkey_detection == userSettings["Hotkeys"]["Playback_Start"]
-                and self.macro.record == False
-                and self.macro.playback == False
-                and self.main_app.macro_recorded == True
+                and not self.macro.record
+                and not self.macro.playback
+                and self.main_app.macro_recorded
             ):
                 self.macro.start_playback()
 
             elif (
                 self.hotkey_detection == userSettings["Hotkeys"]["Playback_Stop"]
-                and self.macro.record == False
-                and self.macro.playback == True
+                and not self.macro.record
+                and self.macro.playback
             ):
                 self.macro.stop_playback(by_hotkey)
 

--- a/src/macro/macro.py
+++ b/src/macro/macro.py
@@ -197,7 +197,7 @@ class Macro:
             sleep(secondsToWait)
         for repeat in range(repeat_times):
             for events in range(len(self.macro_events["events"])):
-                if self.playback == False:
+                if not self.playback:
                     self.unPressEverything(keyToUnpress)
                     return
                 if userSettings["Others"]["Fixed_timestamp"] > 0:
@@ -223,7 +223,7 @@ class Macro:
                         self.macro_events["events"][events]["x"],
                         self.macro_events["events"][events]["y"],
                     )
-                    if self.macro_events["events"][events]["pressed"] == True:
+                    if self.macro_events["events"][events]["pressed"]:
                         self.mouseControl.press(click_func[event_type])
                     else:
                         self.mouseControl.release(click_func[event_type])
@@ -235,7 +235,7 @@ class Macro:
                     )
 
                 elif event_type == "keyboardEvent":  # Keyboard Press,Release
-                    if self.macro_events["events"][events]["key"] != None:
+                    if self.macro_events["events"][events]["key"] is not None:
                         try:
                             keyToPress = (
                                 self.macro_events["events"][events]["key"]
@@ -248,19 +248,16 @@ class Macro:
                                         keyToPress = vk_nb[keyToPress]
                                     except:
                                         keyToPress = None
-                            if self.playback == True:
-                                if keyToPress != None:
-                                    if (
-                                        self.macro_events["events"][events]["pressed"]
-                                        == True
-                                    ):
+                            if self.playback:
+                                if keyToPress is not None:
+                                    if self.macro_events["events"][events]["pressed"]:
                                         self.keyboardControl.press(keyToPress)
                                         if keyToPress not in keyToUnpress:
                                             keyToUnpress.append(keyToPress)
                                     else:
                                         self.keyboardControl.release(keyToPress)
                         except ValueError as e:
-                            if keyToPress == None:
+                            if keyToPress is None:
                                 pass
                             else:
                                 messagebox.showerror("Error", f"Error during playback \"{e}\". Please open an issue on Github.")

--- a/src/windows/main/main_app.py
+++ b/src/windows/main/main_app.py
@@ -130,7 +130,7 @@ class MainApp(Window):
             wantToSave = confirm_save(self)
             if wantToSave:
                 RecordFileManagement(self, self.menu).save_macro()
-            elif wantToSave == None:
+            elif wantToSave is None:
                 return
         if platform.lower() != "darwin":
             self.icon.stop()


### PR DESCRIPTION
Boolean comparisons should not be done via `==` in python.
See: https://peps.python.org/pep-0008/#programming-recommendations

```
Don’t compare boolean values to True or False using ==:
# Correct:
if greeting:

# Wrong:
if greeting == True:

# Wrong:
if greeting is True:
```