### PR TITLE
Ensure the working directory is correct

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+import os
+
 from sys import platform
 
 from windows import MainApp
@@ -8,4 +10,5 @@ if platform.lower() == "win32":
     ctypes.windll.shcore.SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)
 
 if __name__ == "__main__":
+    os.chdir(os.path.dirname(os.path.realname(__file__)))
     MainApp()


### PR DESCRIPTION
When the working directory is wrong, the program fails when it tries to access the icon in the assets directory. This happens, for example, when launching the main.py directly from the Windows shell.

```
Traceback (most recent call last):
  File "C:\path\to\PyMacroRecord-1.4.2\src\main.py", line 11, in <module>
    MainApp()
           ^^
  File "C:\path\to\PyMacroRecord-1.4.2\src\windows\main\main_app.py", line 45, in __init__
    self.iconbitmap(resource_path(path. join("assets", "logo.ico")))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\tkinter\__init__.py", line 2275, in wm_iconbitmap
    return self.tk.call('wm', 'iconbitmap', self._w, bitmap)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_tkinter.TclError: bitmap "C:\WINDOWS\system32\assets\logo.ico" not defined
```