### PR TITLE
Closes #107 - Display loaded .pmr file somewhere

### DIFF
--- a/src/langs/de.json
+++ b/src/langs/de.json
@@ -16,7 +16,8 @@
       "confirm": "Bestätigen",
       "information": "Informationen",
       "restart_software_text": "Sie müssen das Programm neu starten, damit die Änderung übernommen wird.",
-      "load_macro_settings": "Macro-Einstellungen laden?"
+      "load_macro_settings": "Macro-Einstellungen laden?",
+      "untitled_file_name": "Unbenannt.pmr"
     },
     "new_version": {
       "title": "Software update",

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -16,7 +16,8 @@
       "confirm": "Confirm",
       "information": "Information",
       "restart_software_text": "You need to restart the software for it to take effect.",
-      "load_macro_settings": "Import macro settings too?"
+      "load_macro_settings": "Import macro settings too?",
+      "untitled_file_name": "Untitled.pmr"
     },
     "new_version": {
       "title": "Software update",

--- a/src/langs/eo.json
+++ b/src/langs/eo.json
@@ -16,7 +16,8 @@
       "confirm": "Konfirmi",
       "information": "Informo",
       "restart_software_text": "Necesas relanĉi la programon, por ke ĝi efektiviĝas.",
-      "load_macro_settings": "Ĉu importi ankaŭ la makroaj agordoj?"
+      "load_macro_settings": "Ĉu importi ankaŭ la makroaj agordoj?",
+      "untitled_file_name": "Sentitolo.pmr"
     },
     "new_version": {
       "title": "Programĝisdatiĝo",

--- a/src/macro/macro.py
+++ b/src/macro/macro.py
@@ -125,6 +125,7 @@ class Macro:
 
         self.main_app.macro_recorded = True
         self.main_app.macro_saved = False
+        self.main_app.update_title()
 
         if userSettings["Minimization"]["When_Recording"]:
             self.main_app.deiconify()

--- a/src/utils/record_file_management.py
+++ b/src/utils/record_file_management.py
@@ -48,6 +48,7 @@ class RecordFileManagement:
                 else:
                     json_macroEvents = dumps(macroData, indent=4)
                 current_file.write(json_macroEvents)
+                self.main_app.update_title(is_saved=True)
         else:
             self.save_macro_as()
 
@@ -85,6 +86,7 @@ class RecordFileManagement:
             self.main_app.macro_recorded = True
             self.main_app.macro_saved = True
             self.main_app.current_file = macroFile.name
+            self.main_app.update_title()
             if "settings" in self.main_app.macro.macro_events:
                 if not self.main_app.settings.settings_dict["Loading"]["Always_import_macro_settings"]:
                     if messagebox.askyesno("PyMacroRecord", self.config_text["global"]["load_macro_settings"]):
@@ -112,3 +114,4 @@ class RecordFileManagement:
         self.main_app.current_file = None
         self.main_app.macro_saved = False
         self.main_app.macro_recorded = False
+        self.main_app.update_title()

--- a/src/windows/main/main_app.py
+++ b/src/windows/main/main_app.py
@@ -189,6 +189,6 @@ class MainApp(Window):
         if self.current_file != None:
             file_name = self.current_file
         else:
-            file_name = 'untitled.pmr'
+            file_name = self.text_content.get("global",{}).get("untitled_file_name","Untitled.pmr")
             
         self.title(f"PyMacroRecord - {file_name}{'*' if not is_saved else ''}")

--- a/src/windows/main/main_app.py
+++ b/src/windows/main/main_app.py
@@ -47,7 +47,7 @@ class MainApp(Window):
     """Main windows of the application"""
 
     def __init__(self):
-        super().__init__("PyMacroRecord", 350, 200)
+        super().__init__("PyMacroRecord", 700, 400)
         self.attributes("-topmost", 1)
         if platform == "win32":
             self.iconbitmap(resource_path(path.join("assets", "logo.ico")))
@@ -91,9 +91,11 @@ class MainApp(Window):
             self.playBtn = Button(self.center_frame, image=self.playImg, command=self.macro.start_playback)
             self.macro_recorded = True
             self.macro_saved = True
+            self.current_file = sys.argv[1]
         else:
             self.playBtn = Button(self.center_frame, image=self.playImg, state=DISABLED)
         self.playBtn.pack(side=LEFT, padx=50)
+        self.update_title()
 
         # Record Button
         self.recordImg = PhotoImage(file=resource_path(path.join("assets", "button", "record.png")))
@@ -180,3 +182,13 @@ class MainApp(Window):
                         NewVerAvailable(self, self.version.new_version)
             except Exception:
                 pass
+    
+    def update_title(self, is_saved:bool | None = None):
+        is_saved = self.macro_saved if is_saved == None else is_saved
+        
+        if self.current_file != None:
+            file_name = self.current_file
+        else:
+            file_name = 'untitled.pmr'
+            
+        self.title(f"PyMacroRecord - {file_name}{'*' if not is_saved else ''}")

--- a/src/windows/main/main_app.py
+++ b/src/windows/main/main_app.py
@@ -47,7 +47,7 @@ class MainApp(Window):
     """Main windows of the application"""
 
     def __init__(self):
-        super().__init__("PyMacroRecord", 700, 400)
+        super().__init__("PyMacroRecord", 350, 200)
         self.attributes("-topmost", 1)
         if platform == "win32":
             self.iconbitmap(resource_path(path.join("assets", "logo.ico")))


### PR DESCRIPTION
Recently, I saw [this](https://github.com/LOUDO56/PyMacroRecord/issues/107) issue sitting in the repository and had to agree. It'd be pretty handy to view the name of the currently opened file.

So I looked  a little bit into the coding, and added it to the best of my understanding:

The main window class `MainApp` received a new method (`update_title`), which sets the title of the window, to the currently loaded file (`self.current_file`), indicating a star if the file is unsaved (`self.macro_saved`).
This class is called everywhere, where either variable is changed, to adapt the title of the main app window.
The only exception are the `save` and `save_as` method in class `RecordFileManagement`. As either redirect to the `save` method, I only adapted the `save` method, right after the macro contents has been written into the current file.

Last, I also added a new translation option ("content" -> "global" -> "untitled_file_name"), which stores the name of untitled files, and also provided the translations for English, German and Esperanto.
If this translation is not maintained, "Untitled.pmr" will be used as a default, so no language version breaks.

Here we have the unsaved and untitled file; so right after opening PyMacroRecord:

<img width="779" height="128" alt="bildo" src="https://github.com/user-attachments/assets/69ffe2c9-a8f9-4727-8432-4f842fc38049" />

Here it has been saved:

<img width="779" height="128" alt="bildo" src="https://github.com/user-attachments/assets/91b64019-d1ed-43db-92b6-318170bc6685" />

And here, a new macro has been recorded, making the file _unsaved_ again:

<img width="779" height="128" alt="bildo" src="https://github.com/user-attachments/assets/70af3f01-7a96-43d2-82bc-b5574aca651a" />

Of course, saving now makes the star disappear, indicating that the file has been properly saved.

I hope this approach is fine or at least may serve as some kind of reference.